### PR TITLE
Update/layout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
@@ -32,6 +33,7 @@ GEM
       ruby2_keywords
     faraday-net_http (1.0.1)
     ffi (1.15.0)
+    ffi (1.15.0-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (212)
@@ -213,6 +215,8 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.11.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.2-x64-mingw32)
+      racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -247,15 +251,20 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2021.1)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
+    wdm (0.1.1)
     webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
   arm64-darwin-20
+  x64-mingw32
 
 DEPENDENCIES
   github-pages (~> 212)
@@ -267,4 +276,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/_includes/blurbs.html
+++ b/_includes/blurbs.html
@@ -1,0 +1,12 @@
+<article class="commentary">
+	{% if artist_blurb %}
+	<h1>Words from the artist:</h1>
+	{{ artist_blurb | markdownify  }}
+	{% endif %}
+</article>
+<article class="commentary">
+	{% if 4156_blurb %}
+	<h1>4125:</h1>
+	{{ 4156_blurb | markdownify  }}
+	{% endif %}
+</article>

--- a/_layouts/art.html
+++ b/_layouts/art.html
@@ -1,23 +1,35 @@
 ---
 layout: default
 ---
-<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+<main class="art h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 
-  <header class="post-header">
-    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
-    <h2>{{page.artist}},{{page.year}}</h2>
-    <h3>{{page.edition}}</h3>
-  </header>
+	<div class="art-content e-content" itemprop="articleBody">
+		{% if page.type == "image" %}
+		<img src="{{ page.art_url }}" alt="{{ page.title | escape }} by {{page.artist}}" />
+		{% else if page.type == "video" %}
+		<video controls autoplay muted loop controlsList="nodownload">
+			<source src="{{ page.art_url }}">
+			Your browser does not support the video tag.
+		</video>
+		{% else if page.type == "audio" %}
+		{% else %}
+		yeet
+		{% endif %}
+	</div>
 
-  <div class="post-content e-content" itemprop="articleBody">
-    <img src="{{ page.art_url }}" />
-    {{ content }}
-    }
-  </div>
+	<div class="art-details">
+		<h1 class="art-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+		<h2>by <a href="{{ page.artist_url }}">{{ page.artist }}</a> c. {{page.year}}</h2>
+		<p class="bold">{{page.edition}}</p>
+	</div>
 
-  {%- if site.disqus.shortname -%}
-    {%- include disqus_comments.html -%}
-  {%- endif -%}
+	{%- if site.disqus.shortname -%}
+	{%- include disqus_comments.html -%}
+	{%- endif -%}
 
-  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
-</article>
+	<a class="u-url" href="{{ page.url | relative_url }}"></a>
+</main>
+
+<div class="double-column">
+	{{content}}
+</div>

--- a/_layouts/art.html
+++ b/_layouts/art.html
@@ -19,7 +19,7 @@ layout: default
 
 	<div class="art-details">
 		<h1 class="art-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
-		<h2>by <a href="{{ page.artist_url }}">{{ page.artist }}</a> c. {{page.year}}</h2>
+		<h2>by <a href="{{ page.artist_url }}">{{ page.artist }}</a> c.&nbsp;{{page.year}}</h2>
 		<p class="bold">{{page.edition}}</p>
 	</div>
 

--- a/_posts/2021-03-17-post-debt.markdown
+++ b/_posts/2021-03-17-post-debt.markdown
@@ -2,33 +2,22 @@
 layout: art
 title: Post Debt
 art_url: https://ipfs.pixura.io/ipfs/QmauvHamQVLWXNpdoKLimJsTLmbUrc7M9NewQz3g3R88qg
+type: image
 artist: XCOPY
+artist_url: https://superrare.co/XCOPY
 year: 2018
 edition: 1 of 1
 date:   2021-03-17 12:23:29 -0400
 categories: xcopy
 ---
 
-You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
+{% capture 4156_blurb %}
+### Two words:
+- mark
+- down
 
-Jekyll requires blog post files to be named according to the following format:
+That's Life is a 1966 album by Frank Sinatra, supported by a studio orchestra arranged and conducted by Ernie Freeman. The album is notable for its title song, "That's Life", which proved to be a top five hit for Sinatra at a time when rock music dominated the music charts.That's Life was released on CD in May 1998, two weeks before Sinatra's death at the age of 82
+{% endcapture %}
 
-`YEAR-MONTH-DAY-title.MARKUP`
 
-Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
-
-Jekyll also offers powerful support for code snippets:
-
-{% highlight ruby %}
-def print_hi(name)
-  puts "Hi, #{name}"
-end
-print_hi('Tom')
-#=> prints 'Hi, Tom' to STDOUT.
-{% endhighlight %}
-
-Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
-
-[jekyll-docs]: https://jekyllrb.com/docs/home
-[jekyll-gh]:   https://github.com/jekyll/jekyll
-[jekyll-talk]: https://talk.jekyllrb.com/
+{% include blurbs.html %}

--- a/_posts/2021-03-19-machine-learn.markdown
+++ b/_posts/2021-03-19-machine-learn.markdown
@@ -1,0 +1,27 @@
+---
+layout: art
+title: Machine learn!
+art_url: https://ipfs.pixura.io/ipfs/QmXFjVhT4MKYdeJpN2ntLuZaE4YwqZZg4LZVrVrvwnpUiF/SR_machine.mp4
+type: video #image | video | audio
+artist: untitledarmy
+artist_url: https://superrare.co/untitledarmy
+year: 2020
+edition: 1 of 1
+date:   2021-03-19 12:23:29 -0400
+categories: art
+---
+
+{% capture artist_blurb %}
+Alexa, why do humans cry? As machines learn about the human soul, how are they dealing with that? The blockchain is processing all these amazing art, colors, ideas, blood, and bone experiences, now living forever into zeros and ones. Blockchain welcome to our blockpain. This piece is a 1080x1350 px loop. Art and sounds created by the UntitledArmy.
+{% endcapture %}
+
+{% capture 4156_blurb %}
+### Two words:
+- mark
+- down
+
+That's Life is a 1966 album by Frank Sinatra, supported by a studio orchestra arranged and conducted by Ernie Freeman. The album is notable for its title song, "That's Life", which proved to be a top five hit for Sinatra at a time when rock music dominated the music charts.That's Life was released on CD in May 1998, two weeks before Sinatra's death at the age of 82
+{% endcapture %}
+
+
+{% include blurbs.html %}

--- a/_posts/2021-03-20-an-80s-power.markdown
+++ b/_posts/2021-03-20-an-80s-power.markdown
@@ -1,0 +1,18 @@
+---
+layout: art
+title: "An 80s Power Ballad About CryptoPunks 4156 and 6965 | Song A Day #4434"
+art_url: https://ipfs.pixura.io/ipfs/QmfXAA3Y3pD796kRsW5i4x7xv8bQj4jp9Mj2S2Y9VQN4EM/Punks41566965.mp4
+type: video # image | video 
+artist: JonathanMann
+artist_url: https://superrare.co/jonathanmann
+year: 2020
+edition: 1 of 1
+date:   2021-03-20 00:09:29 +0200
+categories: art
+---
+
+{% capture artist_blurb %}
+On February 18th and February 19th, the CryptoPunk apes #4156 and #6965 sold for $1 Million and $2 Million respectively. Here is a song to commemorate this wild occasion.
+{% endcapture %}
+
+{% include blurbs.html %}

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -47,5 +47,6 @@ $on-laptop:        800px !default;
 @import
   "minima/base",
   "minima/layout",
-  "minima/syntax-highlighting"
+  "minima/syntax-highlighting",
+  "minima/art"
 ;

--- a/_sass/minima/_art.scss
+++ b/_sass/minima/_art.scss
@@ -51,7 +51,6 @@ video, img, audio {
 		text-align: center;
 		max-height: 80vh;
 		video, img, audio {
-			min-width: 500px;
 			min-height: 500px;
 			max-width: 100%;
 			max-height: 80vh;
@@ -91,4 +90,54 @@ video, img, audio {
 		}
 	}
 
+}
+
+
+@include media-query($on-palm) {
+	.art, .double-column {
+		max-width: 100%;
+		flex-direction: column;
+		justify-content: flex-start;
+		align-items: center;
+		height: auto;
+		margin-bottom: 50px;
+
+		
+		.art-content {
+			width: 100%;
+			margin-right: 0;
+
+			video, img, audio {
+				min-width: 100%;
+				min-height: 100%;
+				max-width: 100%;
+				max-height: 100%;
+				width: 100%;
+				height: auto;
+			}
+			
+		}
+
+		.art-details {
+			width: 100%;
+			text-align: center;
+
+		}
+
+		.commentary {
+			width: 100%;
+			margin: 0;
+
+			&:nth-child(1) {
+				width: 100%;
+				margin: 0;
+			}
+
+			&:nth-child(2) {
+				width: 100%;
+				margin: 0;
+				margin-top: 50px;
+			}
+		}
+	}
 }

--- a/_sass/minima/_art.scss
+++ b/_sass/minima/_art.scss
@@ -1,0 +1,94 @@
+$apeColor: #739eb1;
+$apeCap: #1b4ae2;
+
+html, body {
+	height: 100%;
+
+	p, h1, h2 {
+		line-height: 1.625em;
+	}
+}
+
+// .bold {
+// 	font-weight: bolder;	
+// }
+
+// h1, h2, h3, h4, h5 {
+// 	font-family: serif;
+// 	font-weight: bolder;
+// 	margin-bottom: 0;
+// }
+
+a {
+	&:link, &:visited {
+		color: inherit;
+		text-decoration: wavy;
+	}
+}
+
+video, img, audio {
+	max-width: 100%;
+	max-height: 100%;
+}
+
+.wrapper {
+	max-width: 100vw;
+}
+
+.art {
+	max-width: 80%;
+	max-width: 80vw;
+	height: 75vh;
+	margin: 0 auto 100px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-around;
+	align-items: center;
+
+	.art-content {
+		width: 60%;
+		margin-right: 50px;
+		text-align: center;
+		max-height: 80vh;
+		video, img, audio {
+			min-width: 500px;
+			min-height: 500px;
+			max-width: 100%;
+			max-height: 80vh;
+		}
+			
+	}
+
+	.art-details {
+		padding: 30px;
+		// border: 1px solid;
+		// border-radius: 30px;
+		// box-shadow: 0px 0px 80px #ddd,
+		// 			10px 10px 40px #ddd,
+		// 			-10px -10px 40px #fff,;
+		width: 40%;
+	}
+}
+
+.double-column {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-around;
+	align-items: flex-start;
+	max-width: 80%;
+	max-width: 80vw;
+	margin: 0 auto;
+
+	.commentary {
+		max-width: 800px;
+		&:nth-child(1) {
+			width: 60%;
+			margin-right: 50px;
+		}
+
+		&:nth-child(2) {
+			width: 40%;
+		}
+	}
+
+}

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -2,7 +2,7 @@
  * Site header
  */
 .site-header {
-  border-top: 5px solid $grey-color-dark;
+//   border-top: 5px solid $grey-color-dark;
   border-bottom: 1px solid $grey-color-light;
   min-height: $spacing-unit * 1.865;
 


### PR DESCRIPTION
# Main updates
### Branched to update/layout for clarity
I've just made a branch for some separation on my end

---
### Added extra metadata fields
I've added extra fields for semantic purposes, namely:
- `artist_url` so we can link to the artists' pages
  - if you would like we could probably have a list of all their links and socials too - I'd probably put that in some sort of tooltip or have a hover to reveal type thing so that it doesn't intrude into the "art wall"
- `type` so we can specify what type of media we're dealing with (this is mostly for displaying correct HTML elements)

---
### Updated art layout
I've updated the `_layout/art.html` page to accommodate for the new metadata - have a look and tell me if you like what you see.

#### Added split blurbs
With this I've created a way to separate how you would write posts (calling them `blurbs` in the code) for the art.
They're split into `4156_blurb` and `artist_blurb` - each of the current post shows off how this looks with the 3 use cases, namely:
- Only artist blurb
- Only 4156 blurb
- Both artist and 4165 blurb

---
### Responsiveness
I've set up a very basic layout for mobile as well.